### PR TITLE
Errors from `assembly_type` kwarg

### DIFF
--- a/firedrake_ts/solving_utils.py
+++ b/firedrake_ts/solving_utils.py
@@ -164,8 +164,7 @@ class _TSContext(object):
             self.F,
             tensor=self._F,
             bcs=self.bcs_F,
-            form_compiler_parameters=self.fcp,
-            assembly_type="residual",
+            form_compiler_parameters=self.fcp
         )
 
         if self.G is not None:
@@ -174,8 +173,7 @@ class _TSContext(object):
                 self.G,
                 tensor=self._G,
                 bcs=self.bcs_G,
-                form_compiler_parameters=self.fcp,
-                assembly_type="residual",
+                form_compiler_parameters=self.fcp
             )
             self.rhs_projection_parameters = rhs_projection_parameters
             self.project_rhs = project_rhs
@@ -588,8 +586,7 @@ class _TSContext(object):
             tensor=self._jac,
             bcs=self.bcs_J,
             form_compiler_parameters=self.fcp,
-            mat_type=self.mat_type,
-            assembly_type="residual",
+            mat_type=self.mat_type
         )
 
     @cached_property
@@ -620,8 +617,7 @@ class _TSContext(object):
             tensor=self._pjac,
             bcs=self.bcs_Jp,
             form_compiler_parameters=self.fcp,
-            mat_type=self.pmat_type,
-            assembly_type="residual",
+            mat_type=self.pmat_type
         )
 
     @cached_property
@@ -696,8 +692,7 @@ class _TSContext(object):
                 tensor=self._rhs_jac,
                 bcs=self.bcs_dGdu,
                 form_compiler_parameters=self.fcp,
-                mat_type=self.mat_type,
-                assembly_type="residual",
+                mat_type=self.mat_type
             )
         else:
             return None


### PR DESCRIPTION
Seven tests are currently failing against the [latest version](https://github.com/firedrakeproject/firedrake/releases/tag/Firedrake_20220411.0) of firedrake.  Looks like firedrakeproject/firedrake#1983 refactored `assemble.py`, including removing the `assemble_type` kwarg.

Initial function:
https://github.com/firedrakeproject/firedrake/blob/1e0f9ed8ed9e6ea1a627471730dda0bddb7fd1fa/firedrake/assemble.py#L134-L169

Current version:
https://github.com/firedrakeproject/firedrake/blob/a77a4996d61da8f8b5710589e1a754357a79886f/firedrake/assemble.py#L223-L284

This conflicts with things like the `assemble_residual` function in `firedrake_ts.solving_utils._TSContext`, which hardcodes `assemble_type` as an argument to `assemble`:
https://github.com/IvanYashchuk/firedrake-ts/blob/879935387e486870308101e6d1bd8f393c762bea/firedrake_ts/solving_utils.py#L189-L196.

The rest of the call signature in `firedrake.assemble` looks the same to me, so seems like just removing the kwarg seems to work.  That fixed 6/7 of the failed tests.